### PR TITLE
bundle update at 2021-04-18 02:05:24 UTC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     graphiql-rails (1.7.0)
       railties
       sprockets-rails
-    graphql (1.12.7)
+    graphql (1.12.8)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [graphql](https://github.com/rmosolgo/graphql-ruby): [`1.12.7...1.12.8`](https://github.com/rmosolgo/graphql-ruby/compare/v1.12.7...v1.12.8)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
