### PR TITLE
bundle update at 2021-06-06 02:05:46 UTC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
@@ -83,7 +83,7 @@ GEM
     graphiql-rails (1.7.0)
       railties
       sprockets-rails
-    graphql (1.12.10)
+    graphql (1.12.12)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.2)
@@ -101,7 +101,7 @@ GEM
     mini_mime (1.0.3)
     minitest (5.14.4)
     nio4r (2.5.7)
-    nokogiri (1.11.5-x86_64-linux)
+    nokogiri (1.11.7-x86_64-linux)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.1.1)
@@ -172,16 +172,16 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
-    rubocop (1.15.0)
+    rubocop (1.16.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.5.0, < 2.0)
+      rubocop-ast (>= 1.7.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.5.0)
+    rubocop-ast (1.7.0)
       parser (>= 3.0.1.1)
     rubocop-rails (2.10.1)
       activesupport (>= 4.2.0)
@@ -209,7 +209,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.4.2)
@@ -242,4 +242,4 @@ RUBY VERSION
    ruby 3.0.0p0
 
 BUNDLED WITH
-   2.2.17
+   2.2.19


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby): [`1.1.8...1.1.9`](https://github.com/ruby-concurrency/concurrent-ruby/compare/v1.1.8...v1.1.9)
* [ ] [graphql](https://github.com/rmosolgo/graphql-ruby): [`1.12.10...1.12.12`](https://github.com/rmosolgo/graphql-ruby/compare/v1.12.10...v1.12.12)
* [ ] [nokogiri](https://github.com/sparklemotion/nokogiri): [`1.11.5...1.11.7`](https://github.com/sparklemotion/nokogiri/compare/v1.11.5...v1.11.7)
* [ ] [rubocop](https://github.com/rubocop/rubocop): [`1.15.0...1.16.0`](https://github.com/rubocop/rubocop/compare/v1.15.0...v1.16.0)
* [ ] [rubocop-ast](https://github.com/rubocop/rubocop-ast): [`1.5.0...1.7.0`](https://github.com/rubocop/rubocop-ast/compare/v1.5.0...v1.7.0)
* [ ] [websocket-driver](https://github.com/faye/websocket-driver-ruby): [`0.7.3...0.7.4`](https://github.com/faye/websocket-driver-ruby/compare/0.7.3...0.7.4)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
