### PR TITLE
bundle update at 2021-11-14 02:06:06 UTC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
       rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.12.0)
+    rubocop-ast (1.13.0)
       parser (>= 3.0.1.1)
     rubocop-rails (2.12.4)
       activesupport (>= 4.2.0)
@@ -195,9 +195,9 @@ GEM
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.2)
-      actionpack (>= 4.0)
-      activesupport (>= 4.0)
+    sprockets-rails (3.3.0)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
     thor (1.1.0)
@@ -242,4 +242,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.2.30
+   2.2.31


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [rubocop-ast](https://github.com/rubocop/rubocop-ast): [`1.12.0...1.13.0`](https://github.com/rubocop/rubocop-ast/compare/v1.12.0...v1.13.0)
* [ ] [sprockets-rails](https://github.com/rails/sprockets-rails): [`3.2.2...3.3.0`](https://github.com/rails/sprockets-rails/compare/v3.2.2...v3.3.0)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
