### PR TITLE
bundle update at 2022-03-06 02:05:28 UTC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     graphiql-rails (1.8.0)
       railties
       sprockets-rails
-    graphql (2.0.1)
+    graphql (2.0.2)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     io-wait (0.2.1)
@@ -235,7 +235,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (4.0.2)
+    sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [graphql](https://github.com/rmosolgo/graphql-ruby): [`2.0.1...2.0.2`](https://github.com/rmosolgo/graphql-ruby/compare/v2.0.1...v2.0.2)
* [ ] [sprockets](https://github.com/rails/sprockets): `4.0.2...4.0.3`

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
