### PR TITLE
bundle update at 2023-10-01 02:05:33 UTC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,12 +93,12 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    ffi (1.15.5)
+    ffi (1.16.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    goldiloader (4.2.0)
-      activerecord (>= 5.2, < 7.2)
-      activesupport (>= 5.2, < 7.2)
+    goldiloader (5.0.0)
+      activerecord (>= 6.1, < 7.2)
+      activesupport (>= 6.1, < 7.2)
     graphiql-rails (1.9.0)
       railties
       sprockets-rails
@@ -133,7 +133,7 @@ GEM
       net-protocol
     net-protocol (0.2.1)
       timeout
-    net-smtp (0.3.3)
+    net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.9)
     nokogiri (1.15.4-x86_64-linux)
@@ -211,7 +211,7 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
-    rubocop (1.56.3)
+    rubocop (1.56.4)
       base64 (~> 0.1.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -225,13 +225,13 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
-    rubocop-rails (2.21.1)
+    rubocop-rails (2.21.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
-    selenium-webdriver (4.12.0)
+    selenium-webdriver (4.13.1)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -257,13 +257,13 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    websocket (1.2.9)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.11)
+    zeitwerk (2.6.12)
 
 PLATFORMS
   x86_64-linux
@@ -295,4 +295,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.4.19
+   2.4.20


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [ffi](https://github.com/ffi/ffi): [`1.15.5...1.16.2`](https://github.com/ffi/ffi/compare/v1.15.5...v1.16.2)
* [ ] [goldiloader](https://github.com/salsify/goldiloader): [`4.2.0...5.0.0`](https://github.com/salsify/goldiloader/compare/v4.2.0...v5.0.0)
* [ ] [net-smtp](https://github.com/ruby/net-smtp): [`0.3.3...0.4.0`](https://github.com/ruby/net-smtp/compare/v0.3.3...v0.4.0)
* [ ] [rubocop](https://github.com/rubocop/rubocop): [`1.56.3...1.56.4`](https://github.com/rubocop/rubocop/compare/v1.56.3...v1.56.4)
* [ ] [rubocop-rails](https://github.com/rubocop/rubocop-rails): [`2.21.1...2.21.2`](https://github.com/rubocop/rubocop-rails/compare/v2.21.1...v2.21.2)
* [ ] [selenium-webdriver](https://github.com/SeleniumHQ/selenium): `4.12.0...4.13.1`
* [ ] [websocket](https://github.com/imanel/websocket-ruby): [`1.2.9...1.2.10`](https://github.com/imanel/websocket-ruby/compare/v1.2.9...v1.2.10)
* [ ] [zeitwerk](https://github.com/fxn/zeitwerk): [`2.6.11...2.6.12`](https://github.com/fxn/zeitwerk/compare/v2.6.11...v2.6.12)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
