### PR TITLE
bundle update at 2024-02-18 02:05:42 UTC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,9 +86,9 @@ GEM
     concurrent-ruby (1.2.3)
     crass (1.0.6)
     date (3.3.4)
-    diff-lcs (1.5.0)
+    diff-lcs (1.5.1)
     erubi (1.12.0)
-    factory_bot (6.4.5)
+    factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
@@ -102,8 +102,7 @@ GEM
     graphiql-rails (1.9.0)
       railties
       sprockets-rails
-    graphql (2.2.6)
-      racc (~> 1.4)
+    graphql (2.2.9)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
@@ -126,8 +125,8 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    minitest (5.21.2)
-    net-imap (0.4.9.1)
+    minitest (5.22.2)
+    net-imap (0.4.10)
       date
       net-protocol
     net-pop (0.1.2)
@@ -195,14 +194,14 @@ GEM
       ffi (~> 1.0)
     regexp_parser (2.9.0)
     rexml (3.2.6)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
+      rspec-support (~> 3.13.0)
     rspec-rails (6.1.1)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
@@ -211,7 +210,7 @@ GEM
       rspec-expectations (~> 3.12)
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
-    rspec-support (3.12.1)
+    rspec-support (3.13.0)
     rubocop (1.60.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -248,7 +247,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.1-x86_64-linux)
+    sqlite3 (1.7.2-x86_64-linux)
     thor (1.3.0)
     timeout (0.4.1)
     tzinfo (2.0.6)
@@ -265,7 +264,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.12)
+    zeitwerk (2.6.13)
 
 PLATFORMS
   x86_64-linux
@@ -297,4 +296,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.5.5
+   2.5.6


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [diff-lcs](https://github.com/halostatue/diff-lcs): `1.5.0...1.5.1`
* [ ] [factory_bot](https://github.com/thoughtbot/factory_bot): [`6.4.5...6.4.6`](https://github.com/thoughtbot/factory_bot/compare/v6.4.5...v6.4.6)
* [ ] [graphql](https://github.com/rmosolgo/graphql-ruby): [`2.2.6...2.2.9`](https://github.com/rmosolgo/graphql-ruby/compare/v2.2.6...v2.2.9)
* [ ] [minitest](https://github.com/minitest/minitest): [`5.21.2...5.22.2`](https://github.com/minitest/minitest/compare/v5.21.2...v5.22.2)
* [ ] [net-imap](https://github.com/ruby/net-imap): [`0.4.9.1...0.4.10`](https://github.com/ruby/net-imap/compare/v0.4.9.1...v0.4.10)
* [ ] [rspec-core](https://github.com/rspec/rspec-core): [`3.12.2...3.13.0`](https://github.com/rspec/rspec-core/compare/v3.12.2...v3.13.0)
* [ ] [rspec-expectations](https://github.com/rspec/rspec-expectations): [`3.12.3...3.13.0`](https://github.com/rspec/rspec-expectations/compare/v3.12.3...v3.13.0)
* [ ] [rspec-mocks](https://github.com/rspec/rspec-mocks): [`3.12.6...3.13.0`](https://github.com/rspec/rspec-mocks/compare/v3.12.6...v3.13.0)
* [ ] [rspec-support](https://github.com/rspec/rspec-support): [`3.12.1...3.13.0`](https://github.com/rspec/rspec-support/compare/v3.12.1...v3.13.0)
* [ ] [sqlite3](https://github.com/sparklemotion/sqlite3-ruby): [`1.7.1...1.7.2`](https://github.com/sparklemotion/sqlite3-ruby/compare/v1.7.1...v1.7.2)
* [ ] [zeitwerk](https://github.com/fxn/zeitwerk): [`2.6.12...2.6.13`](https://github.com/fxn/zeitwerk/compare/v2.6.12...v2.6.13)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
