### PR TITLE
bundle update at 2025-03-02 02:06:53 UTC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,9 +112,9 @@ GEM
     goldiloader (5.4.0)
       activerecord (>= 6.1, < 8.1)
       activesupport (>= 6.1, < 8.1)
-    graphiql-rails (1.10.1)
+    graphiql-rails (1.10.4)
       railties
-    graphql (2.4.9)
+    graphql (2.4.11)
       base64
       fiber-storage
       logger
@@ -236,7 +236,7 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
-    rexml (3.4.0)
+    rexml (3.4.1)
     rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -265,7 +265,7 @@ GEM
     rswag-ui (2.16.0)
       actionpack (>= 5.2, < 8.1)
       railties (>= 5.2, < 8.1)
-    rubocop (1.72.1)
+    rubocop (1.73.1)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -276,9 +276,9 @@ GEM
       rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.38.0)
+    rubocop-ast (1.38.1)
       parser (>= 3.3.1.0)
-    rubocop-rails (2.30.0)
+    rubocop-rails (2.30.2)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -295,7 +295,7 @@ GEM
       sprockets-rails
       tilt
     securerandom (0.4.1)
-    selenium-webdriver (4.28.0)
+    selenium-webdriver (4.29.1)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
@@ -318,8 +318,8 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (2.5.0-x86_64-linux-gnu)
-    stringio (3.1.3)
+    sqlite3 (2.6.0-x86_64-linux-gnu)
+    stringio (3.1.5)
     thor (1.3.2)
     tilt (2.6.0)
     timeout (0.4.3)
@@ -328,7 +328,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri (1.0.2)
+    uri (1.0.3)
     useragent (0.16.11)
     web-console (4.2.1)
       actionview (>= 6.0.0)
@@ -342,7 +342,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.1)
+    zeitwerk (2.7.2)
 
 PLATFORMS
   x86_64-linux
@@ -382,4 +382,4 @@ RUBY VERSION
    ruby 3.4.1p0
 
 BUNDLED WITH
-   2.6.3
+   2.6.5


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [graphiql-rails](https://github.com/rmosolgo/graphiql-rails): [`1.10.1...1.10.4`](https://github.com/rmosolgo/graphiql-rails/compare/v1.10.1...v1.10.4)
* [ ] [graphql](https://github.com/rmosolgo/graphql-ruby): [`2.4.9...2.4.11`](https://github.com/rmosolgo/graphql-ruby/compare/v2.4.9...v2.4.11)
* [ ] [rexml](https://github.com/ruby/rexml): [`3.4.0...3.4.1`](https://github.com/ruby/rexml/compare/v3.4.0...v3.4.1)
* [ ] [rubocop](https://github.com/rubocop/rubocop): [`1.72.1...1.73.1`](https://github.com/rubocop/rubocop/compare/v1.72.1...v1.73.1)
* [ ] [rubocop-ast](https://github.com/rubocop/rubocop-ast): [`1.38.0...1.38.1`](https://github.com/rubocop/rubocop-ast/compare/v1.38.0...v1.38.1)
* [ ] [rubocop-rails](https://github.com/rubocop/rubocop-rails): [`2.30.0...2.30.2`](https://github.com/rubocop/rubocop-rails/compare/v2.30.0...v2.30.2)
* [ ] [selenium-webdriver](https://github.com/SeleniumHQ/selenium): `4.28.0...4.29.1`
* [ ] [sqlite3](https://github.com/sparklemotion/sqlite3-ruby): [`2.5.0...2.6.0`](https://github.com/sparklemotion/sqlite3-ruby/compare/v2.5.0...v2.6.0)
* [ ] [stringio](https://github.com/ruby/stringio): [`3.1.3...3.1.5`](https://github.com/ruby/stringio/compare/v3.1.3...v3.1.5)
* [ ] [uri](https://github.com/ruby/uri): [`1.0.2...1.0.3`](https://github.com/ruby/uri/compare/v1.0.2...v1.0.3)
* [ ] [zeitwerk](https://github.com/fxn/zeitwerk): [`2.7.1...2.7.2`](https://github.com/fxn/zeitwerk/compare/v2.7.1...v2.7.2)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
