### PR TITLE
bundle update at 2025-04-20 02:07:31 UTC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,9 +92,9 @@ GEM
       xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.0)
+    connection_pool (2.5.1)
     crass (1.0.6)
-    csv (3.3.3)
+    csv (3.3.4)
     date (3.4.1)
     diff-lcs (1.6.1)
     docile (1.4.1)
@@ -105,8 +105,8 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
-    ffi (1.17.1-x86_64-linux-gnu)
-    fiber-storage (1.0.0)
+    ffi (1.17.2-x86_64-linux-gnu)
+    fiber-storage (1.0.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
     goldiloader (5.4.0)
@@ -114,7 +114,7 @@ GEM
       activesupport (>= 6.1, < 8.1)
     graphiql-rails (1.10.4)
       railties
-    graphql (2.5.2)
+    graphql (2.5.4)
       base64
       fiber-storage
       logger
@@ -165,8 +165,8 @@ GEM
     nokogiri (1.18.7-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.1)
-    parallel (1.26.3)
-    parser (3.3.7.4)
+    parallel (1.27.0)
+    parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
     pp (0.6.2)
@@ -188,7 +188,7 @@ GEM
     puma (6.6.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.12)
+    rack (3.1.13)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-session (2.1.0)
@@ -313,8 +313,9 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (4.2.1)
+    sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
+      logger
       rack (>= 2.2.4, < 4)
     sprockets-rails (3.5.2)
       actionpack (>= 6.1)
@@ -384,4 +385,4 @@ RUBY VERSION
    ruby 3.4.1p0
 
 BUNDLED WITH
-   2.6.7
+   2.6.8


### PR DESCRIPTION
**Updated RubyGems:**

* [ ] [connection_pool](https://github.com/mperham/connection_pool): [`2.5.0...2.5.1`](https://github.com/mperham/connection_pool/compare/v2.5.0...v2.5.1)
* [ ] [csv](https://github.com/ruby/csv): [`3.3.3...3.3.4`](https://github.com/ruby/csv/compare/v3.3.3...v3.3.4)
* [ ] [ffi](https://github.com/ffi/ffi): [`1.17.1...1.17.2`](https://github.com/ffi/ffi/compare/v1.17.1...v1.17.2)
* [ ] [fiber-storage](https://github.com/ioquatix/fiber-storage): [`1.0.0...1.0.1`](https://github.com/ioquatix/fiber-storage/compare/v1.0.0...v1.0.1)
* [ ] [graphql](https://github.com/rmosolgo/graphql-ruby): [`2.5.2...2.5.4`](https://github.com/rmosolgo/graphql-ruby/compare/v2.5.2...v2.5.4)
* [ ] [parallel](https://github.com/grosser/parallel): [`1.26.3...1.27.0`](https://github.com/grosser/parallel/compare/v1.26.3...v1.27.0)
* [ ] [parser](https://github.com/whitequark/parser): [`3.3.7.4...3.3.8.0`](https://github.com/whitequark/parser/compare/v3.3.7.4...v3.3.8.0)
* [ ] [rack](https://github.com/rack/rack): [`3.1.12...3.1.13`](https://github.com/rack/rack/compare/v3.1.12...v3.1.13)
* [ ] [sprockets](https://github.com/rails/sprockets): [`4.2.1...4.2.2`](https://github.com/rails/sprockets/compare/v4.2.1...v4.2.2)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
